### PR TITLE
Web f21 integrate components with navigation bar v1

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
-import ParkingStatus from './components/parkingInfo/ParkingStatus'
+import Navbar from './components/navigation/Navbar'
 
 class App extends Component {
   render() {
-    return <ParkingStatus />
+    return <Navbar />
   }
 }
 

--- a/src/components/navigation/NavContent.js
+++ b/src/components/navigation/NavContent.js
@@ -1,0 +1,45 @@
+import React, { Fragment } from 'react'
+import { NavLink } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import Button from '@material-ui/core/Button'
+import Spinner from '../util/Spinner'
+import firebaseApp from '../../firebase'
+
+const BtnStyle = {
+  fontSize: 20,
+  color: '#1F3864',  // dark blue
+  fontWeight: 'bold',
+  margin: '5px',
+}
+
+const peruEffects = { textShadow: '0px 0px 15px peru, 0px 0px 15px peru' }
+
+const auth = firebaseApp.auth()
+
+const logout = () => {
+  auth.signOut().then(() => {
+    console.log('user signed out')
+  })
+}
+
+const NavContent = ({ login }) => {
+  if (login === null) return (<Spinner />)
+  return (login ? (
+    <Fragment>
+      <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
+      <Button style={BtnStyle} onClick={logout}>Logout</Button>
+    </Fragment>
+  ) : (
+    <Fragment>
+      <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
+      <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
+      <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
+    </Fragment>
+  ))
+}
+
+NavContent.propTypes = {
+  login: PropTypes.bool
+}
+
+export default NavContent

--- a/src/components/navigation/NavHome.js
+++ b/src/components/navigation/NavHome.js
@@ -1,33 +1,16 @@
-import React, { Component } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ParkingStatus from '../parkingInfo/ParkingStatus'
 import LoginForm from '../userAuth/LoginForm'
 import Spinner from '../util/Spinner'
-import firebaseApp from '../../firebase'
 
-let unsubscribeAuth
-const auth = firebaseApp.auth()
-
-export default class NavHome extends Component {
-  state = {
-    login: null
-  }
-
-  componentDidMount() {
-    unsubscribeAuth = auth.onAuthStateChanged(user => {
-      const isLogin = user ? true : false
-      this.setState({ login: isLogin })
-      console.log('login value is', this.state.login)
-    })
-  }
-
-  componentWillUnmount() {
-    unsubscribeAuth()
-    console.log('NavHome unmounted')
-  }
-
-  render() {
-    const { login } = this.state
-    if (login === null) return (<Spinner />)
-    return (login ? <ParkingStatus /> : <LoginForm />)
-  }
+const NavHome = ({login}) => {
+  if (login === null) return (<Spinner />)
+  return (login ? <ParkingStatus /> : <LoginForm />)
 }
+
+NavHome.propTypes = {
+  login: PropTypes.bool
+}
+
+export default NavHome

--- a/src/components/navigation/NavHome.js
+++ b/src/components/navigation/NavHome.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ParkingStatus from '../parkingInfo/ParkingStatus'
-import LoginForm from '../userAuth/LoginForm'
+import LoginReminder from '../userAuth/LoginReminder'
 import Spinner from '../util/Spinner'
 
 const NavHome = ({login}) => {
   if (login === null) return (<Spinner />)
-  return (login ? <ParkingStatus /> : <LoginForm />)
+  return (login ? <ParkingStatus /> : <LoginReminder />)
 }
 
 NavHome.propTypes = {

--- a/src/components/navigation/NavHome.js
+++ b/src/components/navigation/NavHome.js
@@ -4,6 +4,7 @@ import LoginForm from '../userAuth/LoginForm'
 import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
+let unsubscribeAuth
 const auth = firebaseApp.auth()
 
 export default class NavHome extends Component {
@@ -12,11 +13,16 @@ export default class NavHome extends Component {
   }
 
   componentDidMount() {
-    auth.onAuthStateChanged(user => {
+    unsubscribeAuth = auth.onAuthStateChanged(user => {
       const isLogin = user ? true : false
       this.setState({ login: isLogin })
       console.log('login value is', this.state.login)
     })
+  }
+
+  componentWillUnmount() {
+    unsubscribeAuth()
+    console.log('NavHome unmounted')
   }
 
   render() {

--- a/src/components/navigation/NavHome.js
+++ b/src/components/navigation/NavHome.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import ParkingStatus from '../parkingInfo/ParkingStatus'
+import LoginForm from '../userAuth/LoginForm'
+import Spinner from '../util/Spinner'
+import firebaseApp from '../../firebase'
+
+const auth = firebaseApp.auth()
+
+export default class NavHome extends Component {
+  state = {
+    login: null
+  }
+  
+  componentDidMount() {
+    auth.onAuthStateChanged(user => {
+      const isLogin = user ? true : false
+      this.setState({ login: isLogin })
+      console.log('login value is', this.state.login)
+    })
+  }
+
+  render() {
+    const { login } = this.state
+    if (login === null) return (<Spinner />)
+    return (login ? <ParkingStatus /> : <LoginForm />)
+  }
+}

--- a/src/components/navigation/NavHome.js
+++ b/src/components/navigation/NavHome.js
@@ -10,7 +10,7 @@ export default class NavHome extends Component {
   state = {
     login: null
   }
-  
+
   componentDidMount() {
     auth.onAuthStateChanged(user => {
       const isLogin = user ? true : false

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -54,8 +54,8 @@ export default class Navbar extends Component {
             </Toolbar>
           </AppBar>
           <Route exact path='/' render={() => <NavHome login={login} />} />
-          <Route path='/login' component={LoginForm} />
-          <Route path='/signup' component={SignupForm} />
+          <Route path='/login' render={() => <LoginForm login={login} />} />
+          <Route path='/signup' render={() => <SignupForm login={login} />} />
         </Fragment>
       </BrowserRouter>
     )

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -37,7 +37,6 @@ export default class Navbar extends Component {
 
   componentDidMount() {
     unsubscribeAuth = auth.onAuthStateChanged(user => {
-      console.log(user)
       const isLogin = user ? true : false
       this.setState({ login: isLogin })
       console.log('login value is', this.state.login)
@@ -47,6 +46,12 @@ export default class Navbar extends Component {
   componentWillUnmount() {
     unsubscribeAuth()
     console.log('Navbar unmounted')
+  }
+
+  logout = () => {
+    auth.signOut().then(() => {
+      console.log('user signed out')
+    })
   }
 
   render() {
@@ -61,6 +66,7 @@ export default class Navbar extends Component {
               <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
               <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
               <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
+              <Button style={BtnStyle} onClick={this.logout}>Logout</Button>
             </Toolbar>
           </AppBar>
           <Route exact path='/' render={() => <NavHome login={this.state.login} />} />

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -30,7 +30,6 @@ export default class Navbar extends Component {
     unsubscribeAuth = auth.onAuthStateChanged(user => {
       const isLogin = user ? true : false
       this.setState({ login: isLogin })
-      console.log('login value is', this.state.login)
     })
   }
 
@@ -48,7 +47,7 @@ export default class Navbar extends Component {
           <AppBar position="fixed" style={BarStyle}>
             <Toolbar>
               <ImgWrapper>
-                <img src={require('../../img/ipark_logo.png')} alt='missing image' />
+                <img src={require('../../img/ipark_logo.png')} alt='ipark' />
               </ImgWrapper>
               <NavContent login={login} />
             </Toolbar>

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -1,4 +1,4 @@
-import React, { Fragment }  from 'react'
+import React, { Component, Fragment }  from 'react'
 import styled from 'styled-components'
 import { NavLink, BrowserRouter, Route } from 'react-router-dom'
 import AppBar from '@material-ui/core/AppBar'
@@ -7,6 +7,7 @@ import Toolbar from '@material-ui/core/Toolbar'
 import NavHome from './NavHome'
 import LoginForm from '../userAuth/LoginForm'
 import SignupForm from '../userAuth/SignupForm'
+import firebaseApp from '../../firebase'
 
 const ImgWrapper = styled.span`
   padding: 5px 5px 2px 5px;
@@ -26,26 +27,47 @@ const BarStyle = {
 
 const peruEffects = { textShadow: '0px 0px 15px peru, 0px 0px 15px peru' }
 
-const Navbar = () => {
-  return (
-    <BrowserRouter>
-      <Fragment>
-        <AppBar position="fixed" style={BarStyle}>
-          <Toolbar>
-            <ImgWrapper>
-              <img src={require('../../img/ipark_logo.png')} alt='missing image' />
-            </ImgWrapper>
-            <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
-            <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
-            <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
-          </Toolbar>
-        </AppBar>
-        <Route exact path='/' component={NavHome} />
-        <Route path='/login' component={LoginForm} />
-        <Route path='/signup' component={SignupForm} />
-      </Fragment>
-    </BrowserRouter>
-  )
-}
+let unsubscribeAuth
+const auth = firebaseApp.auth()
 
-export default Navbar
+export default class Navbar extends Component {
+  state = {
+    login: null
+  }
+
+  componentDidMount() {
+    unsubscribeAuth = auth.onAuthStateChanged(user => {
+      console.log(user)
+      const isLogin = user ? true : false
+      this.setState({ login: isLogin })
+      console.log('login value is', this.state.login)
+    })
+  }
+
+  componentWillUnmount() {
+    unsubscribeAuth()
+    console.log('Navbar unmounted')
+  }
+
+  render() {
+    return (
+      <BrowserRouter>
+        <Fragment>
+          <AppBar position="fixed" style={BarStyle}>
+            <Toolbar>
+              <ImgWrapper>
+                <img src={require('../../img/ipark_logo.png')} alt='missing image' />
+              </ImgWrapper>
+              <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
+              <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
+              <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
+            </Toolbar>
+          </AppBar>
+          <Route exact path='/' render={() => <NavHome login={this.state.login} />} />
+          <Route path='/login' component={LoginForm} />
+          <Route path='/signup' component={SignupForm} />
+        </Fragment>
+      </BrowserRouter>
+    )
+  }
+}

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -1,31 +1,22 @@
 import React, { Component, Fragment }  from 'react'
 import styled from 'styled-components'
-import { NavLink, BrowserRouter, Route } from 'react-router-dom'
+import { BrowserRouter, Route } from 'react-router-dom'
 import AppBar from '@material-ui/core/AppBar'
-import Button from '@material-ui/core/Button'
 import Toolbar from '@material-ui/core/Toolbar'
+import NavContent from './NavContent'
 import NavHome from './NavHome'
 import LoginForm from '../userAuth/LoginForm'
 import SignupForm from '../userAuth/SignupForm'
+import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 const ImgWrapper = styled.span`
   padding: 5px 5px 2px 5px;
   flex-grow: 1;
 `
-
-const BtnStyle = {
-  fontSize: 20,
-  color: '#1F3864',  // dark blue
-  fontWeight: 'bold',
-  margin: '5px',
-}
-
 const BarStyle = {
   background: '#CEE2F3',
 }
-
-const peruEffects = { textShadow: '0px 0px 15px peru, 0px 0px 15px peru' }
 
 let unsubscribeAuth
 const auth = firebaseApp.auth()
@@ -48,13 +39,9 @@ export default class Navbar extends Component {
     console.log('Navbar unmounted')
   }
 
-  logout = () => {
-    auth.signOut().then(() => {
-      console.log('user signed out')
-    })
-  }
-
   render() {
+    const { login } = this.state
+    if (login === null) return (<Spinner />)
     return (
       <BrowserRouter>
         <Fragment>
@@ -63,13 +50,10 @@ export default class Navbar extends Component {
               <ImgWrapper>
                 <img src={require('../../img/ipark_logo.png')} alt='missing image' />
               </ImgWrapper>
-              <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
-              <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
-              <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
-              <Button style={BtnStyle} onClick={this.logout}>Logout</Button>
+              <NavContent login={login} />
             </Toolbar>
           </AppBar>
-          <Route exact path='/' render={() => <NavHome login={this.state.login} />} />
+          <Route exact path='/' render={() => <NavHome login={login} />} />
           <Route path='/login' component={LoginForm} />
           <Route path='/signup' component={SignupForm} />
         </Fragment>

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -1,30 +1,50 @@
-import React from 'react'
+import React, { Fragment }  from 'react'
 import styled from 'styled-components'
+import { NavLink, BrowserRouter, Route } from 'react-router-dom'
 import AppBar from '@material-ui/core/AppBar'
+import Button from '@material-ui/core/Button'
 import Toolbar from '@material-ui/core/Toolbar'
-import NavItem from './NavItem'
+import NavHome from './NavHome'
 import LoginForm from '../userAuth/LoginForm'
+import SignupForm from '../userAuth/SignupForm'
 
 const ImgWrapper = styled.span`
   padding: 5px 5px 2px 5px;
   flex-grow: 1;
 `
 
+const BtnStyle = {
+  fontSize: 20,
+  color: '#1F3864',  // dark blue
+  fontWeight: 'bold',
+  margin: '5px',
+}
+
+const BarStyle = {
+  background: '#CEE2F3',
+}
+
+const peruEffects = { textShadow: '0px 0px 15px peru, 0px 0px 15px peru' }
+
 const Navbar = () => {
   return (
-    <div>
-      <AppBar position="fixed" style={{ background: '#CEE2F3'}}>
-        <Toolbar>
-          <ImgWrapper>
-            <img src={require('../../img/ipark_logo.png')} alt='missing image' />
-          </ImgWrapper>
-          <NavItem
-            itemTitle='Login'
-            itemContent={<LoginForm />}
-          />
-        </Toolbar>
-      </AppBar>
-    </div>
+    <BrowserRouter>
+      <Fragment>
+        <AppBar position="fixed" style={BarStyle}>
+          <Toolbar>
+            <ImgWrapper>
+              <img src={require('../../img/ipark_logo.png')} alt='missing image' />
+            </ImgWrapper>
+            <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
+            <Button component={NavLink} to='/login' style={BtnStyle} activeStyle={peruEffects}>Login</Button>
+            <Button component={NavLink} to='/signup' style={BtnStyle} activeStyle={peruEffects}>Signup</Button>
+          </Toolbar>
+        </AppBar>
+        <Route exact path='/' component={NavHome} />
+        <Route path='/login' component={LoginForm} />
+        <Route path='/signup' component={SignupForm} />
+      </Fragment>
+    </BrowserRouter>
   )
 }
 

--- a/src/components/parkingInfo/ParkingStatus.js
+++ b/src/components/parkingInfo/ParkingStatus.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import StatusTable from './StatusTable'
 import StatusSummary from './StatusSummary'
 import StatusLegend from './StatusLegend'
+import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 const Wrapper = styled.div`
@@ -78,7 +79,7 @@ class ParkingStatus extends Component {
       )
     }
 
-    return <div>Loading...</div>
+    return <Spinner />
   }
 }
 

--- a/src/components/parkingInfo/ParkingStatus.js
+++ b/src/components/parkingInfo/ParkingStatus.js
@@ -7,15 +7,18 @@ import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 const Wrapper = styled.div`
-  background-color: rgba(0, 0, 0, 0.6);  // Black with Transparency of 40%
+  background-color: rgba(0, 0, 0, 0.6);  /* Black with Transparency of 40% */
   display: inline-block;
-  padding: 60px 130px;
+  padding: 60px 0;
+  width: 100%;
+  height: 80vh;
 `
 
 const GridWrapper = styled.div`
   display: grid;
   grid-template-columns: 221px 418px;
   grid-template-rows: 310px 113px;
+  justify-content: center;
 `
 
 const SummaryCell = styled.div`
@@ -23,7 +26,6 @@ const SummaryCell = styled.div`
 `
 
 const StatusCell = styled.div`
-  padding: 1px 30px 1px 30px;
   grid-column: 2 / 3;
   grid-row: 1 / 3;
 `

--- a/src/components/parkingInfo/ParkingStatus.js
+++ b/src/components/parkingInfo/ParkingStatus.js
@@ -19,6 +19,7 @@ const GridWrapper = styled.div`
   grid-template-columns: 221px 418px;
   grid-template-rows: 310px 113px;
   justify-content: center;
+  margin-top: 20px;
 `
 
 const SummaryCell = styled.div`

--- a/src/components/userAuth/LoginForm.js
+++ b/src/components/userAuth/LoginForm.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
+import { Link, Redirect } from 'react-router-dom'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
+import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 export const Form = styled.form`
@@ -84,6 +85,7 @@ class LoginForm extends Component {
       email: null,
       password: null
     }
+
     handleSubmit = (e) => {
       e.preventDefault()
       const email = this.state.email
@@ -91,21 +93,28 @@ class LoginForm extends Component {
       auth.signInWithEmailAndPassword(email, password)
         .then(UserCredential => {
           console.log('cred valid! Login as', UserCredential.user.email)
-          this.props.handleClose()
         })
         .catch(err => {
           console.log(err.message)
         })
       console.log('Form Submitted \nEmail Adress:', this.state.email, '\nPassword:', this.state.password)
     }
+
     handleChange = (e) => {
       this.setState({ [e.target.name]: e.target.value })
     }
+
     handleCheckbox = () => {
       console.log('Remember User', this.state.email)
     }
+
     render(){
-      return (
+      const { login } = this.props
+      if (login === null) return (<Spinner />)
+
+      return (login ? (
+        <Redirect to ='/' />
+      ) : (
         <div>
           <Form className='LoginForm' onSubmit={this.handleSubmit}>
             <Title>WELCOME TO IPARK</Title>
@@ -133,12 +142,12 @@ class LoginForm extends Component {
             <br/>
           </Form>
         </div>
-      )
+      ))
     }
 }
 
 LoginForm.propTypes = {
-  handleClose: PropTypes.func
+  login: PropTypes.bool
 }
 
 export default LoginForm

--- a/src/components/userAuth/LoginForm.js
+++ b/src/components/userAuth/LoginForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { Link } from 'react-router-dom'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import firebaseApp from '../../firebase'
@@ -48,11 +49,11 @@ export const Button = styled.button`
   }
 `
 
-const ALink = styled.a`
-  font-family: 'Gill Sans', sans-serif;
-  color: white;
-  text-decoration: none;
-`
+const LinkStyle = {
+  fontFamily: 'Gill Sans, sans-serif',
+  color: 'white',
+  textDecoration: 'none'
+}
 
 export const Input = styled.input`
   font-size: 15px;
@@ -128,7 +129,7 @@ class LoginForm extends Component {
             <br/>
             <Button type='submit'>LOGIN</Button>
             <br/>
-            <LabelSmall><ALink href='https://github.com/iparkmse'>Forget Password</ALink></LabelSmall>
+            <LabelSmall><Link to='/signup' style={LinkStyle}>Forget Password</Link></LabelSmall> {/* TODO: create reset-pass component */}
             <br/>
           </Form>
         </div>

--- a/src/components/userAuth/LoginForm.js
+++ b/src/components/userAuth/LoginForm.js
@@ -7,8 +7,8 @@ import firebaseApp from '../../firebase'
 
 export const Form = styled.form`
   background-color: rgba(0, 0, 0, 0.6);  /* Black with Transparency of 40% */
-  width: 600px;
-  /*height: 500px;*/
+  width: 100%;
+  height: 80vh;
   padding: 60px 10px;
   text-align: center;
   vertical-align: center;

--- a/src/components/userAuth/LoginReminder.js
+++ b/src/components/userAuth/LoginReminder.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+const Wrapper = styled.div`
+  background-color: rgba(0, 0, 0, 0.6);
+  width: 100%;
+  height: 80vh;
+  padding-top: 60px;
+  margin-top: 40px;
+  text-align: center;
+  vertical-align: center;
+  font-family: 'Gill Sans', sans-serif;
+  font-size: 20px;
+  color: white;
+  line-height: 2.0;
+`
+
+const LoginReminder = () => {
+  return (
+    <Wrapper>
+      Please <Link to='/login'>log in</Link> first to use the iPark services.
+      <br />
+      New to iPark? It&apos;s free to <Link to='/signup'>sign up</Link>
+    </Wrapper>
+  )
+}
+
+export default LoginReminder

--- a/src/components/userAuth/SignupForm.js
+++ b/src/components/userAuth/SignupForm.js
@@ -72,7 +72,7 @@ export default class SignupForm extends Component {
     e.preventDefault()
     console.log('sign up successfully')
     auth.createUserWithEmailAndPassword(this.state.email, this.state.pass).then(cred => {
-      db.ref('users/' + `${this.state.fName}_${this.state.lName}_${cred.user.uid}`).set({
+      db.ref(`users/${this.state.fName}_${this.state.lName}_${cred.user.uid}`).set({
         uid: cred.user.uid,
         first_name: this.state.fName,
         last_name: this.state.lName,

--- a/src/components/userAuth/SignupForm.js
+++ b/src/components/userAuth/SignupForm.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Button, Form, Input, Title } from './LoginForm'
+import SignupSuccess from './SignupSuccess'
+import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 const GridWrapper = styled.div`
@@ -88,12 +91,17 @@ export default class SignupForm extends Component {
   }
 
   render() {
-    const errors = validate(this.state.email, this.state.pass, this.state.confirmPass, this.state.fName, this.state.lName, this.state.licensePlate)
+    const { login } = this.props
+    const { email, pass, confirmPass, fName, lName, licensePlate } = this.state
+    const errors = validate(email, pass, confirmPass, fName, lName, licensePlate)
     const isDisabled = Object.keys(errors).some(i => errors[i])
 
     const shouldMarkError = field => errors[field] && this.state.touched[field]
 
-    return (
+    if (login === null) return (<Spinner />)
+    return (login ? (
+      <SignupSuccess />
+    ) : (
       <Form onSubmit={this.handleSubmit}>
         <Title>WELCOME TO IPARK</Title>
         <GridWrapper>
@@ -108,6 +116,10 @@ export default class SignupForm extends Component {
         </GridWrapper>
         <Button disabled={isDisabled} type='submit'>SIGN UP</Button>
       </Form>
-    )
+    ))
   }
+}
+
+SignupForm.propTypes = {
+  login: PropTypes.bool
 }

--- a/src/components/userAuth/SignupForm.js
+++ b/src/components/userAuth/SignupForm.js
@@ -106,7 +106,7 @@ export default class SignupForm extends Component {
           <Input type='password' name='confirmPass' placeholder='confirm password' onChange={this.handleChange} onBlur={this.handleBlur} error={shouldMarkError('confirmPass')} required />
           <Input type='text' name='licensePlate' placeholder='license plate' onChange={this.handleChange} onBlur={this.handleBlur} error={shouldMarkError('licensePlate')} required />
         </GridWrapper>
-        <Button disabled={isDisabled} type='submit'>Sign Up</Button>
+        <Button disabled={isDisabled} type='submit'>SIGN UP</Button>
       </Form>
     )
   }

--- a/src/components/userAuth/SignupSuccess.js
+++ b/src/components/userAuth/SignupSuccess.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+const Wrapper = styled.div`
+  background-color: rgba(0, 0, 0, 0.6);
+  width: 100%;
+  height: 80vh;
+  padding-top: 60px;
+  margin-top: 40px;
+  text-align: center;
+  vertical-align: center;
+  font-family: 'Gill Sans', sans-serif;
+  font-size: 20px;
+  color: white;
+`
+
+const SignupSuccess = () => {
+  return (
+    <Wrapper>
+      Thanks for signing up. Please feel free to use our services.
+      <br />
+      <Link to='/'>Click here to check the latest parking status </Link>
+    </Wrapper>
+  )
+}
+
+export default SignupSuccess

--- a/src/components/userAuth/SignupSuccess.js
+++ b/src/components/userAuth/SignupSuccess.js
@@ -13,6 +13,7 @@ const Wrapper = styled.div`
   font-family: 'Gill Sans', sans-serif;
   font-size: 20px;
   color: white;
+  line-height: 2.0;
 `
 
 const SignupSuccess = () => {

--- a/src/components/util/Spinner.js
+++ b/src/components/util/Spinner.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from "styled-components";
+import styled, { keyframes } from 'styled-components'
 
 const rotate = keyframes`
   from {
@@ -8,7 +8,7 @@ const rotate = keyframes`
   to {
     transform: rotate(360deg);
   }
-`;
+`
 
 // Here we create a component that will rotate everything we pass in over one second
 const Spinner = styled.div`
@@ -21,6 +21,6 @@ const Spinner = styled.div`
   width: 50px;
   height: 50px;
   margin: 100px auto;
-`;
+`
 
-export default Spinner;
+export default Spinner

--- a/src/components/util/Spinner.js
+++ b/src/components/util/Spinner.js
@@ -1,0 +1,26 @@
+import styled, { keyframes } from "styled-components";
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+// Here we create a component that will rotate everything we pass in over one second
+const Spinner = styled.div`
+  display: block;
+  animation: ${rotate} 1s linear infinite;
+
+  border: 10px solid #f3f3f3;
+  border-radius: 50%;
+  border-top: 10px solid #555;
+  width: 50px;
+  height: 50px;
+  margin: 100px auto;
+`;
+
+export default Spinner;

--- a/stories/index.js
+++ b/stories/index.js
@@ -9,6 +9,7 @@ import LoginForm from '../src/components/userAuth/LoginForm'
 import SignupForm from '../src/components/userAuth/SignupForm'
 import Navbar from '../src/components/navigation/Navbar'
 import NavItem from '../src/components/navigation/NavItem'
+import NavHome from '../src/components/navigation/NavHome'
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
 
 let buttonStyle = {
@@ -58,4 +59,7 @@ storiesOf('React Component', module)
   ))
   .add('Navigation item', () => (
     <NavItem itemTitle='login' itemContent={<LoginForm />} />
+  ))
+  .add('Navigation home', () => (
+    <NavHome />
   ))


### PR DESCRIPTION
## :rocket: What does this PR implement/fix?  
- Use react-router-dom to integrate parking status, login form, and signup form with navigation bar.  

## :book: Where should the reviewers start?  
- /navigation dir, Navbar.js, NavHome.js, NavContent.js  
- /auth dir: LoginForm.js, SignupForm.js

## :movie_camera: Screencast/Demo  
N/A

## :bulb: Additional context you want to provide?  
- git fetch and then checkout the branch (f21), run command `npm start` to test.  
- Make sure all the flows are correct: 
  - When user not login, parking status page will show info to tell users to log in or sign up. If the user has logged in, the user can view the parking status.  
  - When user not login, user can fill the login form. After login, the user will be redirected to the homepage where the user can view parking status.  
  - Signup form can only be seen when the user didn't log in. After signup or login, the signup form shouldn't be there.  
  - User shouldn't see login or signup on the navigation bar if the users have logged in; instead, the user can see a logout button.