### PR TITLE
Web f27 reservation v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17780,6 +17780,11 @@
         }
       }
     },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "16.6.3",
     "react-router-dom": "4.3.1",
     "react-scripts": "2.1.1",
-    "styled-components": "4.1.2"
+    "styled-components": "4.1.2",
+    "underscore": "1.9.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>iPark</title>
   </head>
   <body>
     <noscript>

--- a/src/components/navigation/NavContent.js
+++ b/src/components/navigation/NavContent.js
@@ -27,6 +27,7 @@ const NavContent = ({ login }) => {
   return (login ? (
     <Fragment>
       <Button component={NavLink} exact to='/' style={BtnStyle} activeStyle={peruEffects}>Parking Status</Button>
+      <Button component={NavLink} exact to='/reservation' style={BtnStyle} activeStyle={peruEffects}>reservation</Button>
       <Button style={BtnStyle} onClick={logout}>Logout</Button>
     </Fragment>
   ) : (

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -39,7 +39,7 @@ export default class Navbar extends Component {
         login: isLogin,
         myUid: uid
       })
-      if (uid) {
+      if (uid && !this.state.plates) {
         db.ref(`users/${uid}`).once('value')
           .then(snapshot => {
             this.setState({ plates: snapshot.val().licensePlate })

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -9,6 +9,7 @@ import LoginForm from '../userAuth/LoginForm'
 import SignupForm from '../userAuth/SignupForm'
 import ResMain from '../reservation/ResMain'
 import Spinner from '../util/Spinner'
+import { CredContextProvider } from '../../contexts/CredContext'
 import firebaseApp from '../../firebase'
 
 const ImgWrapper = styled.span`
@@ -24,13 +25,18 @@ const auth = firebaseApp.auth()
 
 export default class Navbar extends Component {
   state = {
-    login: null
+    login: null,
+    uid: null
   }
 
   componentDidMount() {
     unsubscribeAuth = auth.onAuthStateChanged(user => {
       const isLogin = user ? true : false
-      this.setState({ login: isLogin })
+      const uid = user? user.uid : null
+      this.setState({ 
+        login: isLogin,
+        uid: uid
+      })
     })
   }
 
@@ -44,7 +50,7 @@ export default class Navbar extends Component {
     if (login === null) return (<Spinner />)
     return (
       <BrowserRouter>
-        <Fragment>
+        <CredContextProvider value={{...this.state}}>
           <AppBar position="fixed" style={BarStyle}>
             <Toolbar>
               <ImgWrapper>
@@ -57,7 +63,7 @@ export default class Navbar extends Component {
           <Route path='/login' render={() => <LoginForm login={login} />} />
           <Route path='/signup' render={() => <SignupForm login={login} />} />
           <Route path='/reservation' render={() => <ResMain login={login} />} />
-        </Fragment>
+        </CredContextProvider>
       </BrowserRouter>
     )
   }

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -41,9 +41,9 @@ export default class Navbar extends Component {
       })
       if (uid) {
         db.ref(`users/${uid}`).once('value')
-         .then(snapshot => {
-           this.setState({ plates: snapshot.val().licensePlate })
-         })
+          .then(snapshot => {
+            this.setState({ plates: snapshot.val().licensePlate })
+          })
       }
     })
   }

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment }  from 'react'
+import React, { Component }  from 'react'
 import styled from 'styled-components'
 import { BrowserRouter, Route } from 'react-router-dom'
 import AppBar from '@material-ui/core/AppBar'
@@ -33,7 +33,7 @@ export default class Navbar extends Component {
     unsubscribeAuth = auth.onAuthStateChanged(user => {
       const isLogin = user ? true : false
       const uid = user? user.uid : null
-      this.setState({ 
+      this.setState({
         login: isLogin,
         uid: uid
       })

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -22,11 +22,13 @@ const BarStyle = {
 
 let unsubscribeAuth
 const auth = firebaseApp.auth()
+const db = firebaseApp.database()
 
 export default class Navbar extends Component {
   state = {
     login: null,
-    uid: null
+    myUid: null,
+    plates: null
   }
 
   componentDidMount() {
@@ -35,8 +37,14 @@ export default class Navbar extends Component {
       const uid = user? user.uid : null
       this.setState({
         login: isLogin,
-        uid: uid
+        myUid: uid
       })
+      if (uid) {
+        db.ref(`users/${uid}`).once('value')
+         .then(snapshot => {
+           this.setState({ plates: snapshot.val().licensePlate })
+         })
+      }
     })
   }
 

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -7,6 +7,7 @@ import NavContent from './NavContent'
 import NavHome from './NavHome'
 import LoginForm from '../userAuth/LoginForm'
 import SignupForm from '../userAuth/SignupForm'
+import ResMain from '../reservation/ResMain'
 import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
@@ -55,6 +56,7 @@ export default class Navbar extends Component {
           <Route exact path='/' render={() => <NavHome login={login} />} />
           <Route path='/login' render={() => <LoginForm login={login} />} />
           <Route path='/signup' render={() => <SignupForm login={login} />} />
+          <Route path='/reservation' render={() => <ResMain login={login} />} />
         </Fragment>
       </BrowserRouter>
     )

--- a/src/components/reservation/ForbidModal.js
+++ b/src/components/reservation/ForbidModal.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Button from '@material-ui/core/Button'
+import Modal from '@material-ui/core/Modal'
+import Typography from '@material-ui/core/Typography'
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
+import { DateContext } from '../../contexts/DateContext'
+
+
+const modalStyle = {
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '200px',
+  maxWidth: '100%',
+  backgroundColor: 'white',
+  padding: '32px',
+  borderRadius: '10px',
+  boxShadow: '0 3px 7px rgba(0, 0, 0, 0.3)',
+  border: '1px solid rgba(0, 0, 0, 0.3)',
+  textAlign: 'center'
+}
+
+const theme = createMuiTheme({
+  palette: {
+    primary: { main: '#2196f3'}
+  },
+  typography: {
+    useNextVariants: true,
+  }
+})
+
+export default class ForbidModal extends Component {
+  static contextType = DateContext
+  state = {
+    open: this.props.open
+  }
+
+  handleClose = () => {
+    this.setState({ open: false })
+    this.props.closeHandler()
+  }
+
+  componentDidUpdate(oldProps) {
+    const newProps = this.props
+    if (oldProps.open !== newProps.open) {
+      this.setState({ open: newProps.open })
+    }
+  }
+
+  render() {
+    const { open } = this.state
+    return (
+      <MuiThemeProvider theme={theme}>
+        <Modal
+          aria-labelledby='reservation-form-modal'
+          aria-describedby='form-to-make-a-reservation'
+          open={open}
+          onClose={this.handleClose}
+        >
+          <form style={modalStyle}>
+            <Typography variant='body1' id='forbid-modal-body'>
+              Only 1 booking per day
+            </Typography>
+            <Button color='primary' onClick={this.handleClose} style={{marginTop: '15px'}}>OK</Button>
+          </form>
+        </Modal>
+      </MuiThemeProvider>
+    )
+  }
+}
+
+ForbidModal.propTypes = {
+  closeHandler: PropTypes.func,
+  open: PropTypes.bool
+}

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -44,6 +44,7 @@ export default class ResCell extends Component {
     stall: '',
     time: '',
     hours: '1',
+    myUid: ''
   }
 
   handleClick = e => {
@@ -64,7 +65,10 @@ export default class ResCell extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { plates } = this.context
+    const { myUid, plates } = this.context
+    if (myUid && !prevState.myUid) {
+      this.setState({ myUid: myUid })
+    }
     if (plates && !prevState.plates) {
       this.setState({ plates: plates })
     }

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -25,18 +25,19 @@ const FreeCell = styled.div`
 `
 
 
-const ResCell = ({ uid }) => {
+const ResCell = ({ uid, index }) => {
   return (uid ? (
-    <BookedCell>
+    <BookedCell data-index={index}>
       [booked]
     </BookedCell>
   ) : (
-    <FreeCell />
+    <FreeCell data-index={index} />
   ))
 }
 
 ResCell.propTypes = {
-  uid: PropTypes.string
+  uid: PropTypes.string,
+  index: PropTypes.number
 }
 
 export default ResCell

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ResModal from './ResModal'
 import { stalls, times } from './ResTable'
-import { CredContextConsumer } from '../../contexts/CredContext'
+import { CredContext } from '../../contexts/CredContext'
 
 const MyCell = styled.div`
   background-color: moccasin;
@@ -36,8 +36,11 @@ const FreeCell = styled.div`
 `
 
 export default class ResCell extends Component {
+  static contextType = CredContext
+
   state = {
     open: false,
+    plates: '',
     stall: '',
     time: '',
     hours: '1',
@@ -51,7 +54,7 @@ export default class ResCell extends Component {
       this.setState({
         open: true,
         stall: stall,
-        time: time
+        time: time,
       })
     }
   }
@@ -60,28 +63,31 @@ export default class ResCell extends Component {
     this.setState({ open: false })
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { plates } = this.context
+    if (plates && !prevState.plates) {
+      this.setState({ plates: plates })
+    }
+  }
+
   render() {
     const { uid, index } = this.props
+    const { myUid } = this.context
 
-    return (
-      <CredContextConsumer>{context => {
-        if (!uid) return (
-          <FreeCell data-index={index} onClick={this.handleClick}>
-            <ResModal closeHandler={this.handleClose} {...this.state } />
-          </FreeCell>
-        )
-        return (uid === context.myUid ? (
-          <MyCell>
-            [my booking]
-          </MyCell>
-        ) : (
-          <BookedCell data-index={index}>
-            [booked]
-          </BookedCell>
-        ))
-      }}
-      </CredContextConsumer>
+    if (!uid) return (
+      <FreeCell data-index={index} onClick={this.handleClick}>
+        <ResModal closeHandler={this.handleClose} {...this.state } />
+      </FreeCell>
     )
+    return (uid === myUid ? (
+      <MyCell>
+        [my booking]
+      </MyCell>
+    ) : (
+      <BookedCell data-index={index}>
+        [booked]
+      </BookedCell>
+    ))
   }
 }
 

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -24,20 +24,20 @@ const FreeCell = styled.div`
   }
 `
 
-
-const ResCell = ({ uid, index }) => {
-  return (uid ? (
-    <BookedCell data-index={index}>
-      [booked]
-    </BookedCell>
-  ) : (
-    <FreeCell data-index={index} />
-  ))
+export default class ResCell extends Component {
+  render() {
+    const { uid, index } = this.props
+    return (uid ? (
+      <BookedCell data-index={index}>
+        [booked]
+      </BookedCell>
+    ) : (
+      <FreeCell data-index={index} />
+    ))
+  }
 }
 
 ResCell.propTypes = {
   uid: PropTypes.string,
   index: PropTypes.number
 }
-
-export default ResCell

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ResModal from './ResModal'
 import { stalls, times } from './ResTable'
+import { CredContextConsumer } from '../../contexts/CredContext'
+
+const MyCell = styled.div`
+  background-color: moccasin;
+  border: 1px black solid;
+  border-left: none;
+  color: palevioletred;
+  font-weight: bold;
+`
 
 const BookedCell = styled.div`
   background-color: papayawhip;
@@ -53,15 +62,26 @@ export default class ResCell extends Component {
 
   render() {
     const { uid, index } = this.props
-    return (uid ? (
-      <BookedCell data-index={index}>
-        [booked]
-      </BookedCell>
-    ) : (
-      <FreeCell data-index={index} onClick={this.handleClick}>
-        <ResModal closeHandler={this.handleClose} {...this.state } />
-      </FreeCell>
-    ))
+
+    return (
+      <CredContextConsumer>{context => {
+        if (!uid) return (
+          <FreeCell data-index={index} onClick={this.handleClick}>
+            <ResModal closeHandler={this.handleClose} {...this.state } />
+          </FreeCell>
+        )
+        return (uid === context.myUid ? (
+          <MyCell>
+            [my booking]
+          </MyCell>
+        ) : (
+          <BookedCell data-index={index}>
+            [booked]
+          </BookedCell>
+        ))
+      }}
+      </CredContextConsumer>
+    )
   }
 }
 

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -75,10 +75,13 @@ export default class ResCell extends Component {
   }
 
   render() {
-    const { uid, index } = this.props
+    const { uid, index, hasBooked } = this.props
     const { myUid } = this.context
-
-    if (!uid) return (
+    
+    if (hasBooked && !uid) return (
+      <FreeCell data-index={index} />
+    )
+    else if (!uid) return (
       <FreeCell data-index={index} onClick={this.handleClick}>
         <ResModal closeHandler={this.handleClose} {...this.state } />
       </FreeCell>

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -77,7 +77,7 @@ export default class ResCell extends Component {
   render() {
     const { uid, index, hasBooked } = this.props
     const { myUid } = this.context
-    
+
     if (hasBooked && !uid) return (
       <FreeCell data-index={index} />
     )

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -29,7 +29,6 @@ const FreeCell = styled.div`
 export default class ResCell extends Component {
   state = {
     open: false,
-    plates: 'ABC123',
     stall: '',
     time: '',
     hours: '1',

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -1,6 +1,8 @@
 import React, {Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import ResModal from './ResModal'
+import { stalls, times } from './ResTable'
 
 const BookedCell = styled.div`
   background-color: papayawhip;
@@ -25,6 +27,31 @@ const FreeCell = styled.div`
 `
 
 export default class ResCell extends Component {
+  state = {
+    open: false,
+    plates: 'ABC123',
+    stall: '',
+    time: '',
+    hours: '1',
+  }
+
+  handleClick = e => {
+    const index = e.target.getAttribute('data-index')
+    const stall = stalls[Math.floor(index / times.length)]
+    const time = times[index % times.length]
+    if (index !== null) {
+      this.setState({
+        open: true,
+        stall: stall,
+        time: time
+      })
+    }
+  }
+
+  handleClose = () => {
+    this.setState({ open: false })
+  }
+
   render() {
     const { uid, index } = this.props
     return (uid ? (
@@ -32,7 +59,9 @@ export default class ResCell extends Component {
         [booked]
       </BookedCell>
     ) : (
-      <FreeCell data-index={index} />
+      <FreeCell data-index={index} onClick={this.handleClick}>
+        <ResModal closeHandler={this.handleClose} {...this.state } />
+      </FreeCell>
     ))
   }
 }

--- a/src/components/reservation/ResCell.js
+++ b/src/components/reservation/ResCell.js
@@ -2,6 +2,7 @@ import React, {Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ResModal from './ResModal'
+import ForbidModal from './ForbidModal'
 import { stalls, times } from './ResTable'
 import { CredContext } from '../../contexts/CredContext'
 
@@ -79,7 +80,9 @@ export default class ResCell extends Component {
     const { myUid } = this.context
 
     if (hasBooked && !uid) return (
-      <FreeCell data-index={index} />
+      <FreeCell data-index={index} onClick={this.handleClick}>
+        <ForbidModal closeHandler={this.handleClose} open={this.state.open}/>
+      </FreeCell>
     )
     else if (!uid) return (
       <FreeCell data-index={index} onClick={this.handleClick}>

--- a/src/components/reservation/ResMain.js
+++ b/src/components/reservation/ResMain.js
@@ -1,12 +1,20 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
 import ResCalendar from './ResCalendar'
 import { reformattedDays } from './ResCalendar'
 import ResTable from './ResTable'
 import RES_DATA from './res_data'
+import LoginReminder from '../userAuth/LoginReminder'
+import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
 
 const db = firebaseApp.database()
 const dayLength = reformattedDays.length
+
+const Wrapper = styled.div`
+  margin-top: 60px;
+`
 
 export default class ResMain extends Component {
   updateRes = (ResCalendarData, index) => {
@@ -62,13 +70,21 @@ export default class ResMain extends Component {
   }
 
   render() {
+    const { login } = this.props
     const { date, resData } = this.state
 
-    return (
-      <Fragment>
+    if (login === null) return (<Spinner />)
+    return (login ? (
+      <Wrapper>
         <ResCalendar resMainHandler={this.updateRes}/>
         <ResTable date={date} resData={resData}/>
-      </Fragment>
-    )
+      </Wrapper>
+    ) : (
+      <LoginReminder />
+    ))
   }
+}
+
+ResMain.propTypes = {
+  login: PropTypes.bool
 }

--- a/src/components/reservation/ResMain.js
+++ b/src/components/reservation/ResMain.js
@@ -67,13 +67,6 @@ export default class ResMain extends Component {
     })
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.resData !== prevState.resData) {
-      console.log('previous:', prevState.resData)
-      console.log('now:', this.state.resData)
-    }
-  }
-
   componentWillUnmount() {
     reformattedDays.forEach(day => {
       db.ref(`reservation/${day}`).off()

--- a/src/components/reservation/ResMain.js
+++ b/src/components/reservation/ResMain.js
@@ -20,12 +20,14 @@ const Wrapper = styled.div`
 export default class ResMain extends Component {
   updateRes = (ResCalendarData, index) => {
     this.setState({
+      index: index,
       date: ResCalendarData,
-      resData: this.state.dbData[index]
+      resData: {...this.state.dbData[index]}
     })
   }
 
   state = {
+    index: 0,
     date: reformattedDays[0],
     resData: null,
     dbData: new Array(dayLength)  // reservation data for X days on database [ {}, ..., {} ]
@@ -44,8 +46,8 @@ export default class ResMain extends Component {
           else tempDbData[i] = snapshot.val()
           if (i === dayLength - 1) {
             this.setState({
-              resData: tempDbData[0],
-              dbData: tempDbData
+              resData: {...tempDbData[0]},
+              dbData: [...tempDbData]
             })
           }
         })
@@ -55,15 +57,22 @@ export default class ResMain extends Component {
       const reservationRef = db.ref(`reservation/${day}`)
       reservationRef.on('child_changed', childSnapshot => {
         const stallName = childSnapshot.key  // i.e. stallA1
-        const copy = this.state.dbData
+        const copy = [...this.state.dbData]
         copy[i][stallName] = childSnapshot.val()
-        this.setState({ dbData: copy })
+        this.setState({ dbData: [...copy] })
+        if (i === this.state.index) {
+          this.setState({ resData: {...copy[i]} })
+        }
       })
     })
   }
 
-  // componentDidUpdate(prevProps, prevState) {
-  // }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.resData !== prevState.resData) {
+      console.log('previous:', prevState.resData)
+      console.log('now:', this.state.resData)
+    }
+  }
 
   componentWillUnmount() {
     reformattedDays.forEach(day => {

--- a/src/components/reservation/ResMain.js
+++ b/src/components/reservation/ResMain.js
@@ -50,19 +50,20 @@ export default class ResMain extends Component {
           }
         })
     })
-  }
 
-  componentDidUpdate() {
-    let copy = this.state.dbData  // ds: [ {}, ..., {} ]
     reformattedDays.forEach((day, i) => {
       const reservationRef = db.ref(`reservation/${day}`)
       reservationRef.on('child_changed', childSnapshot => {
         const stallName = childSnapshot.key  // i.e. stallA1
+        const copy = this.state.dbData
         copy[i][stallName] = childSnapshot.val()
         this.setState({ dbData: copy })
       })
     })
   }
+
+  // componentDidUpdate(prevProps, prevState) {
+  // }
 
   componentWillUnmount() {
     reformattedDays.forEach(day => {
@@ -77,9 +78,9 @@ export default class ResMain extends Component {
     if (login === null) return (<Spinner />)
     return (login ? (
       <Wrapper>
-        <ResCalendar resMainHandler={this.updateRes}/>
+        <ResCalendar resMainHandler={this.updateRes} />
         <DateContextProvider value={date}>
-          <ResTable date={date} resData={resData}/>
+          <ResTable date={date} resData={resData} />
         </DateContextProvider>
       </Wrapper>
     ) : (

--- a/src/components/reservation/ResMain.js
+++ b/src/components/reservation/ResMain.js
@@ -7,6 +7,7 @@ import ResTable from './ResTable'
 import RES_DATA from './res_data'
 import LoginReminder from '../userAuth/LoginReminder'
 import Spinner from '../util/Spinner'
+import { DateContextProvider } from '../../contexts/DateContext'
 import firebaseApp from '../../firebase'
 
 const db = firebaseApp.database()
@@ -77,7 +78,9 @@ export default class ResMain extends Component {
     return (login ? (
       <Wrapper>
         <ResCalendar resMainHandler={this.updateRes}/>
-        <ResTable date={date} resData={resData}/>
+        <DateContextProvider value={date}>
+          <ResTable date={date} resData={resData}/>
+        </DateContextProvider>
       </Wrapper>
     ) : (
       <LoginReminder />

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -30,6 +30,9 @@ const modalStyle = {
 const theme = createMuiTheme({
   palette: {
     primary: { main: '#2196f3'}
+  },
+  typography: {
+    useNextVariants: true,
   }
 })
 

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
 import Button from '@material-ui/core/Button'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import FormControl from '@material-ui/core/FormControl'
@@ -8,6 +9,7 @@ import Radio from '@material-ui/core/Radio'
 import RadioGroup from '@material-ui/core/RadioGroup'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
+import { stalls, times } from './ResTable'
 
 
 const modalStyle = {
@@ -24,18 +26,8 @@ const modalStyle = {
   border: '1px solid rgba(0, 0, 0, 0.3)'
 }
 
-const stallOptions = ['A1', 'A2', 'A3']
-const timeOptions = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
-  '13:00', '14:00', '15:00', '16:00', '17:00', '18:00']
-
 export default class ResModal extends Component {
-  state = {
-    open: false,
-    plates: '',
-    stall: 'A1',
-    time: '7:00',
-    hours: '1',
-  }
+  state = {...this.props}
 
   handleOpen = () => {
     this.setState({ open: true })
@@ -43,17 +35,28 @@ export default class ResModal extends Component {
 
   handleClose = () => {
     this.setState({ open: false })
+    this.props.closeHandler()
   }
 
   handleChange = (e) => {
     this.setState({ [e.target.name]: e.target.value })
   }
 
+  componentDidUpdate(oldProps) {
+    const newProps = this.props
+    if (oldProps.open !== newProps.open) {
+      this.setState({
+        open: newProps.open,
+        time: newProps.time,
+        stall: newProps.stall
+      })
+    }
+  }
+
   render() {
     const { open, plates, stall, time, hours } = this.state
     return (
       <Fragment>
-        <button onClick={this.handleOpen}>Open modal</button>
         <Modal
           aria-labelledby='reservation-form-modal'
           aria-describedby='form-to-make-a-reservation'
@@ -91,7 +94,7 @@ export default class ResModal extends Component {
               margin='normal'
               variant='outlined'
             >
-              {stallOptions.map(stall => (
+              {stalls.map(stall => (
                 <option key={stall} value={stall}>
                   {stall}
                 </option>
@@ -111,7 +114,7 @@ export default class ResModal extends Component {
               margin='normal'
               variant='outlined'
             >
-              {timeOptions.map(time => (
+              {times.map(time => (
                 <option key={time} value={time}>
                   {time}
                 </option>
@@ -139,4 +142,8 @@ export default class ResModal extends Component {
       </Fragment>
     )
   }
+}
+
+ResModal.propTypes = {
+  closeHandler: PropTypes.func
 }

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -203,10 +203,7 @@ export default class ResModal extends Component {
             <Button color='primary' type='submit' style={{margin: '30px 10px 0 0'}} onClick={this.handleSubmit}>RESERVE</Button>
             <Button style={{marginTop: 30}} onClick={this.handleClose}>CANCEL</Button>
             {error && (
-              <Typography 
-                variant='caption'
-                color='error'
-              >
+              <Typography variant='caption' color='error'>
                 Request invalid! The reservation conflicts with other bookings.
                 <br />
                 Please consider changing: 1) stall 2) time 3) hours

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -47,10 +47,6 @@ export default class ResModal extends Component {
     error: false
   }
 
-  handleOpen = () => {
-    this.setState({ open: true })
-  }
-
   handleClose = () => {
     this.setState({ open: false, error: false })
     this.props.closeHandler()
@@ -129,7 +125,7 @@ export default class ResModal extends Component {
           onClose={this.handleClose}
         >
           <form style={modalStyle}>
-            <Typography variant='h6' id='modal-title'>
+            <Typography variant='h6' id='composer-modal-title'>
               Make a reservation
             </Typography>
             <TextField

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -94,7 +94,7 @@ export default class ResModal extends Component {
               />
             )}
             </CredContextConsumer>
-            
+
             <TextField
               id='outlined-select-stall'
               select

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -11,6 +11,7 @@ import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import { stalls, times } from './ResTable'
+import { CredContextConsumer } from '../../contexts/CredContext'
 
 
 const modalStyle = {
@@ -64,7 +65,7 @@ export default class ResModal extends Component {
   }
 
   render() {
-    const { open, plates, stall, time, hours } = this.state
+    const { open, stall, time, hours } = this.state
     return (
       <MuiThemeProvider theme={theme}>
         <Modal
@@ -77,19 +78,23 @@ export default class ResModal extends Component {
             <Typography variant='h6' id='modal-title'>
               Make a reservation
             </Typography>
-            <TextField
-              id='outlined-input-plates'
-              label='Car Plates'
-              type='text'
-              name='plates'
-              value={plates}
-              onChange={this.handleChange}
-              margin='normal'
-              variant='outlined'
-              InputLabelProps={{
-                shrink: true,
-              }}
-            />
+            <CredContextConsumer>{context => (
+              <TextField
+                id='outlined-input-plates'
+                label='Car Plates'
+                type='text'
+                name='plates'
+                value={context.plates}
+                onChange={this.handleChange}
+                margin='normal'
+                variant='outlined'
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            )}
+            </CredContextConsumer>
+            
             <TextField
               id='outlined-select-stall'
               select

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Button from '@material-ui/core/Button'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
@@ -9,6 +9,7 @@ import Radio from '@material-ui/core/Radio'
 import RadioGroup from '@material-ui/core/RadioGroup'
 import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import { stalls, times } from './ResTable'
 
 
@@ -25,6 +26,12 @@ const modalStyle = {
   boxShadow: '0 3px 7px rgba(0, 0, 0, 0.3)',
   border: '1px solid rgba(0, 0, 0, 0.3)'
 }
+
+const theme = createMuiTheme({
+  palette: {
+    primary: { main: '#2196f3'}
+  }
+})
 
 export default class ResModal extends Component {
   state = {...this.props}
@@ -56,7 +63,7 @@ export default class ResModal extends Component {
   render() {
     const { open, plates, stall, time, hours } = this.state
     return (
-      <Fragment>
+      <MuiThemeProvider theme={theme}>
         <Modal
           aria-labelledby='reservation-form-modal'
           aria-describedby='form-to-make-a-reservation'
@@ -139,7 +146,7 @@ export default class ResModal extends Component {
             <Button style={{marginTop: 30}} onClick={this.handleClose}>CANCEL</Button>
           </form>
         </Modal>
-      </Fragment>
+      </MuiThemeProvider>
     )
   }
 }

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -42,14 +42,17 @@ const db = firebaseApp.database()
 
 export default class ResModal extends Component {
   static contextType = DateContext
-  state = {...this.props}
+  state = {
+    ...this.props,
+    error: false
+  }
 
   handleOpen = () => {
     this.setState({ open: true })
   }
 
   handleClose = () => {
-    this.setState({ open: false })
+    this.setState({ open: false, error: false })
     this.props.closeHandler()
   }
 
@@ -94,7 +97,7 @@ export default class ResModal extends Component {
     }
 
     else {
-      console.log('request invalid')
+      this.setState({ error: true })
     }
   }
 
@@ -116,7 +119,7 @@ export default class ResModal extends Component {
   }
 
   render() {
-    const { open, plates, stall, time, hours } = this.state
+    const { open, plates, stall, time, hours, error } = this.state
     return (
       <MuiThemeProvider theme={theme}>
         <Modal
@@ -199,6 +202,16 @@ export default class ResModal extends Component {
             <br />
             <Button color='primary' type='submit' style={{margin: '30px 10px 0 0'}} onClick={this.handleSubmit}>RESERVE</Button>
             <Button style={{marginTop: 30}} onClick={this.handleClose}>CANCEL</Button>
+            {error && (
+              <Typography 
+                variant='caption'
+                color='error'
+              >
+                Request invalid! The reservation conflicts with other bookings.
+                <br />
+                Please consider changing: 1) stall 2) time 3) hours
+              </Typography>
+            )}
           </form>
         </Modal>
       </MuiThemeProvider>

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -1,7 +1,13 @@
 import React, { Component, Fragment } from 'react'
-import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import FormControl from '@material-ui/core/FormControl'
+import FormLabel from '@material-ui/core/FormLabel'
 import Modal from '@material-ui/core/Modal'
+import Radio from '@material-ui/core/Radio'
+import RadioGroup from '@material-ui/core/RadioGroup'
 import TextField from '@material-ui/core/TextField'
+import Typography from '@material-ui/core/Typography'
 
 
 const modalStyle = {
@@ -25,10 +31,10 @@ const timeOptions = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
 export default class ResModal extends Component {
   state = {
     open: false,
-    stall: 'A1',
     plates: '',
+    stall: 'A1',
     time: '7:00',
-    hours: 0,
+    hours: '1',
   }
 
   handleOpen = () => {
@@ -44,7 +50,7 @@ export default class ResModal extends Component {
   }
 
   render() {
-    const { open } = this.state
+    const { open, plates, stall, time, hours } = this.state
     return (
       <Fragment>
         <button onClick={this.handleOpen}>Open modal</button>
@@ -59,10 +65,11 @@ export default class ResModal extends Component {
               Make a reservation
             </Typography>
             <TextField
-              id='outlined-plates-input'
+              id='outlined-input-plates'
               label='Car Plates'
               type='text'
               name='plates'
+              value={plates}
               onChange={this.handleChange}
               margin='normal'
               variant='outlined'
@@ -76,7 +83,7 @@ export default class ResModal extends Component {
               style={{width: 100, marginLeft: 10}}
               label='Stall Select'
               name='stall'
-              value={this.state.stall}
+              value={stall}
               onChange={this.handleChange}
               SelectProps={{
                 native: true
@@ -96,7 +103,7 @@ export default class ResModal extends Component {
               select
               label='Time Select'
               name='time'
-              value={this.state.time}
+              value={time}
               onChange={this.handleChange}
               SelectProps={{
                 native: true
@@ -110,6 +117,23 @@ export default class ResModal extends Component {
                 </option>
               ))}
             </TextField>
+            <FormControl component="fieldset" style={{margin: '10px 0 0 20px'}}>
+              <FormLabel component="legend" style={{fontSize: 12}}>Hours</FormLabel>
+              <RadioGroup
+                aria-label="Hours"
+                name="hours"
+                value={hours}
+                onChange={this.handleChange}
+                row
+              >
+                <FormControlLabel value='1' control={<Radio color='primary' />} label="1" />
+                <FormControlLabel value='2' control={<Radio color='primary' />} label="2" />
+                <FormControlLabel value='3' control={<Radio color='primary' />} label="3" />
+              </RadioGroup>
+            </FormControl>
+            <br />
+            <Button color='primary' type='submit' style={{margin: '30px 10px 0 0'}}>RESERVE</Button>
+            <Button style={{marginTop: 30}} onClick={this.handleClose}>CANCEL</Button>
           </form>
         </Modal>
       </Fragment>

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -11,7 +11,6 @@ import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import { stalls, times } from './ResTable'
-import { CredContextConsumer } from '../../contexts/CredContext'
 
 
 const modalStyle = {
@@ -59,13 +58,14 @@ export default class ResModal extends Component {
       this.setState({
         open: newProps.open,
         time: newProps.time,
-        stall: newProps.stall
+        stall: newProps.stall,
+        plates: newProps.plates
       })
     }
   }
 
   render() {
-    const { open, stall, time, hours } = this.state
+    const { open, plates, stall, time, hours } = this.state
     return (
       <MuiThemeProvider theme={theme}>
         <Modal
@@ -78,23 +78,19 @@ export default class ResModal extends Component {
             <Typography variant='h6' id='modal-title'>
               Make a reservation
             </Typography>
-            <CredContextConsumer>{context => (
-              <TextField
-                id='outlined-input-plates'
-                label='Car Plates'
-                type='text'
-                name='plates'
-                value={context.plates}
-                onChange={this.handleChange}
-                margin='normal'
-                variant='outlined'
-                InputLabelProps={{
-                  shrink: true,
-                }}
-              />
-            )}
-            </CredContextConsumer>
-
+            <TextField
+              id='outlined-input-plates'
+              label='Car Plates'
+              type='text'
+              name='plates'
+              value={plates}
+              onChange={this.handleChange}
+              margin='normal'
+              variant='outlined'
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
             <TextField
               id='outlined-select-stall'
               select

--- a/src/components/reservation/ResModal.js
+++ b/src/components/reservation/ResModal.js
@@ -1,0 +1,118 @@
+import React, { Component, Fragment } from 'react'
+import Typography from '@material-ui/core/Typography'
+import Modal from '@material-ui/core/Modal'
+import TextField from '@material-ui/core/TextField'
+
+
+const modalStyle = {
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '400px',
+  maxWidth: '100%',
+  backgroundColor: 'white',
+  padding: '32px',
+  borderRadius: '10px',
+  boxShadow: '0 3px 7px rgba(0, 0, 0, 0.3)',
+  border: '1px solid rgba(0, 0, 0, 0.3)'
+}
+
+const stallOptions = ['A1', 'A2', 'A3']
+const timeOptions = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
+  '13:00', '14:00', '15:00', '16:00', '17:00', '18:00']
+
+export default class ResModal extends Component {
+  state = {
+    open: false,
+    stall: 'A1',
+    plates: '',
+    time: '7:00',
+    hours: 0,
+  }
+
+  handleOpen = () => {
+    this.setState({ open: true })
+  }
+
+  handleClose = () => {
+    this.setState({ open: false })
+  }
+
+  handleChange = (e) => {
+    this.setState({ [e.target.name]: e.target.value })
+  }
+
+  render() {
+    const { open } = this.state
+    return (
+      <Fragment>
+        <button onClick={this.handleOpen}>Open modal</button>
+        <Modal
+          aria-labelledby='reservation-form-modal'
+          aria-describedby='form-to-make-a-reservation'
+          open={open}
+          onClose={this.handleClose}
+        >
+          <form style={modalStyle}>
+            <Typography variant='h6' id='modal-title'>
+              Make a reservation
+            </Typography>
+            <TextField
+              id='outlined-plates-input'
+              label='Car Plates'
+              type='text'
+              name='plates'
+              onChange={this.handleChange}
+              margin='normal'
+              variant='outlined'
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+            <TextField
+              id='outlined-select-stall'
+              select
+              style={{width: 100, marginLeft: 10}}
+              label='Stall Select'
+              name='stall'
+              value={this.state.stall}
+              onChange={this.handleChange}
+              SelectProps={{
+                native: true
+              }}
+              margin='normal'
+              variant='outlined'
+            >
+              {stallOptions.map(stall => (
+                <option key={stall} value={stall}>
+                  {stall}
+                </option>
+              ))}
+            </TextField>
+            <br />
+            <TextField
+              id='outlined-select-time'
+              select
+              label='Time Select'
+              name='time'
+              value={this.state.time}
+              onChange={this.handleChange}
+              SelectProps={{
+                native: true
+              }}
+              margin='normal'
+              variant='outlined'
+            >
+              {timeOptions.map(time => (
+                <option key={time} value={time}>
+                  {time}
+                </option>
+              ))}
+            </TextField>
+          </form>
+        </Modal>
+      </Fragment>
+    )
+  }
+}

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -44,7 +44,8 @@ const Header = ({ date }) => {
   )
 }
 
-const times = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
+export const stalls = ['A1', 'A2', 'A3']
+export const times = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
   '13:00', '14:00', '15:00', '16:00', '17:00', '18:00']
 
 const TimeCol = () => times.map(time => {

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -8,6 +8,7 @@ const Wrapper = styled.div`
   background-color: rgba(0, 0, 0, 0.6);  /* Black with Transparency of 40% */
   width: 100%;
   margin-top: 20px;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
 `
 
 const ResGrid = styled.div`

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -48,6 +48,8 @@ const Header = ({ date }) => {
 export const stalls = ['A1', 'A2', 'A3']
 export const times = ['7:00', '8:00', '9:00', '10:00', '11:00', '12:00',
   '13:00', '14:00', '15:00', '16:00', '17:00', '18:00']
+export const timesDB = ['a7', 'b8', 'c9', 'd10', 'e11', 'f12',
+  'g13', 'h14', 'i15', 'j16', 'k17', 'l18']
 
 const TimeCol = () => times.map(time => {
   return (

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -69,7 +69,7 @@ export default class ResTable extends Component {
     const newProps = this.props
     const { resData } = newProps
     const { myUid } = this.context
-    if (oldProps.resData !== resData && myUid) {
+    if (oldProps !== this.props && myUid) {
       const resStalls = Object.keys(resData)
       const resInfo = resStalls.map(stall => Object.values(resData[stall]))
       let found = false

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -66,7 +66,7 @@ export default class ResTable extends Component {
   state = {
     hasBooked: null
   }
-  
+
   componentDidUpdate(oldProps) {
     const newProps = this.props
     const { resData } = newProps

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -69,7 +69,7 @@ export default class ResTable extends Component {
             {resInfo.map(stalls => stalls.map(stall => {
               return (
                 <Fragment key={stall.index}>
-                  <ResCell uid={stall.uid} />
+                  <ResCell uid={stall.uid} index={stall.index} />
                 </Fragment>
               )
             }))}

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ResCell from './ResCell'
 import Spinner from '../util/Spinner'
+import { CredContext } from '../../contexts/CredContext'
 
 const Wrapper = styled.div`
   background-color: rgba(0, 0, 0, 0.6);  /* Black with Transparency of 40% */
@@ -60,8 +61,30 @@ const TimeCol = () => times.map(time => {
 })
 
 export default class ResTable extends Component {
+  static contextType = CredContext
+  state = {
+    hasBooked: null
+  }
+  componentDidUpdate(oldProps) {
+    const newProps = this.props
+    const { resData } = newProps
+    const { myUid } = this.context
+    if (oldProps.resData !== resData && myUid) {
+      const resStalls = Object.keys(resData)
+      const resInfo = resStalls.map(stall => Object.values(resData[stall]))
+      let found = false
+      for (let i = 0; i < resInfo.length && !found; i++) {
+        for (let j = 0; j < resInfo[i].length && !found; j++) {
+          if (resInfo[i][j].uid === myUid) found = true
+        }
+      }
+      if (found) this.setState({ hasBooked: true })
+      else this.setState({ hasBooked: false })
+    }
+  }
   render() {
     const { date, resData } = this.props
+    const { hasBooked } = this.state
     if (resData) {
       const resStalls = Object.keys(resData)
       const resInfo = resStalls.map(stall => Object.values(resData[stall]))
@@ -73,7 +96,7 @@ export default class ResTable extends Component {
             {resInfo.map(stalls => stalls.map(stall => {
               return (
                 <Fragment key={stall.index}>
-                  <ResCell uid={stall.uid} index={stall.index} />
+                  <ResCell uid={stall.uid} index={stall.index} hasBooked={hasBooked} />
                 </Fragment>
               )
             }))}

--- a/src/components/reservation/ResTable.js
+++ b/src/components/reservation/ResTable.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { isEqual } from 'underscore'
 import ResCell from './ResCell'
 import Spinner from '../util/Spinner'
 import { CredContext } from '../../contexts/CredContext'
@@ -65,11 +66,12 @@ export default class ResTable extends Component {
   state = {
     hasBooked: null
   }
+  
   componentDidUpdate(oldProps) {
     const newProps = this.props
     const { resData } = newProps
     const { myUid } = this.context
-    if (oldProps !== this.props && myUid) {
+    if (!isEqual(this.props.resData, oldProps.resData)) {
       const resStalls = Object.keys(resData)
       const resInfo = resStalls.map(stall => Object.values(resData[stall]))
       let found = false
@@ -82,6 +84,7 @@ export default class ResTable extends Component {
       else this.setState({ hasBooked: false })
     }
   }
+
   render() {
     const { date, resData } = this.props
     const { hasBooked } = this.state

--- a/src/components/userAuth/SignupForm.js
+++ b/src/components/userAuth/SignupForm.js
@@ -72,7 +72,7 @@ export default class SignupForm extends Component {
     e.preventDefault()
     console.log('sign up successfully')
     auth.createUserWithEmailAndPassword(this.state.email, this.state.pass).then(cred => {
-      db.ref(`users/${this.state.fName}_${this.state.lName}_${cred.user.uid}`).set({
+      db.ref(`users/${cred.user.uid}`).set({
         uid: cred.user.uid,
         first_name: this.state.fName,
         last_name: this.state.lName,

--- a/src/contexts/CredContext.js
+++ b/src/contexts/CredContext.js
@@ -1,3 +1,8 @@
+/**
+ * The context for user creds; used for getting
+ * users' login status and license plates
+ */
+
 import { createContext } from 'react'
 
 export const CredContext = createContext()

--- a/src/contexts/CredContext.js
+++ b/src/contexts/CredContext.js
@@ -1,5 +1,5 @@
 import { createContext } from 'react'
 
-const CredContext = createContext()
+export const CredContext = createContext()
 export const CredContextProvider = CredContext.Provider
 export const CredContextConsumer = CredContext.Consumer

--- a/src/contexts/CredContext.js
+++ b/src/contexts/CredContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const CredContext = createContext()
+export const CredContextProvider = CredContext.Provider
+export const CredContextConsumer = CredContext.Consumer

--- a/src/contexts/DateContext.js
+++ b/src/contexts/DateContext.js
@@ -1,3 +1,7 @@
+/**
+ * The context for reservation date
+ */
+
 import { createContext } from 'react'
 
 export const DateContext = createContext()

--- a/src/contexts/DateContext.js
+++ b/src/contexts/DateContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+export const DateContext = createContext()
+export const DateContextProvider = DateContext.Provider
+export const DateContextConsumer = DateContext.Consumer

--- a/stories/index.js
+++ b/stories/index.js
@@ -12,6 +12,7 @@ import NavItem from '../src/components/navigation/NavItem'
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
 import ResCalendar from '../src/components/reservation/ResCalendar'
 import ResMain from '../src/components/reservation/ResMain'
+import ResModal from '../src/components/reservation/ResModal'
 
 
 let buttonStyle = {
@@ -67,4 +68,7 @@ storiesOf('React Component', module)
   ))
   .add('Reservation main page', () => (
     <ResMain />
+  ))
+  .add('Reservation modal', () => (
+    <ResModal />
   ))

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,15 +1,23 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { storiesOf } from '@storybook/react'
 import { Button } from '@storybook/react/demo'
-import { text, color, object, boolean, number } from '@storybook/addon-knobs'
+import { text, color, object, boolean } from '@storybook/addon-knobs'
 import StarIcon from '@material-ui/icons/Stars'
 import BackupIcon from '@material-ui/icons/Backup'
 
+// userAuth components
 import LoginForm from '../src/components/userAuth/LoginForm'
 import SignupForm from '../src/components/userAuth/SignupForm'
+import LoginReminder from '../src/components/userAuth/LoginReminder'
+
+// navigation components
 import Navbar from '../src/components/navigation/Navbar'
-import NavItem from '../src/components/navigation/NavItem'
+
+// parkingInfo components
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
+
+// reservation components
 import ResCalendar from '../src/components/reservation/ResCalendar'
 import ResMain from '../src/components/reservation/ResMain'
 import ResModal from '../src/components/reservation/ResModal'
@@ -40,35 +48,22 @@ storiesOf('Button', module)
     </Button>
   ))
 
-storiesOf('Span', module)
-  .addWithJSX('span with number', () => <span>{number('Age', 78)}</span>)
-
 storiesOf('Material-UI icon', module)
   .addWithJSX('star icon', () => <StarIcon>Outlined</StarIcon>)
   .addWithJSX('backup icon', () => <BackupIcon>Filled</BackupIcon>)
 
 storiesOf('React Component', module)
-  .add('Login form V1', () => (
-    <LoginForm />
+  .addDecorator(story => (
+    <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
   ))
-  .add('Signup form V1', () => (
-    <SignupForm />
-  ))
-  .add('Parking Status Table', () => (
-    <ParkingStatus />
-  ))
-  .add('Navigation bar', () => (
-    <Navbar />
-  ))
-  .add('Navigation item', () => (
-    <NavItem itemTitle='login' itemContent={<LoginForm />} />
-  ))
-  .add('Reservation calendar', () => (
-    <ResCalendar />
-  ))
-  .add('Reservation main page', () => (
-    <ResMain />
-  ))
-  .add('Reservation modal', () => (
-    <ResModal />
-  ))
+  .add('Login form V1', () => <LoginForm />)
+  .add('Signup form V1', () => <SignupForm />)
+  .add('Login Reminder', () => <LoginReminder />)
+
+  .add('Parking Status Table', () => <ParkingStatus />)
+
+  .add('Navigation bar', () => <Navbar />)
+
+  .add('Reservation calendar', () => <ResCalendar />)
+  .add('Reservation main page', () => <ResMain login={true} />)
+  .add('Reservation modal', () => <ResModal open={true} />)


### PR DESCRIPTION
## :rocket: What does this PR implement/fix?  
- Implement a reservation composer modal.

## :book: Where should the reviewers start?  
- Under /reservation, look at:
  - ResModal  
  - ResMain  
  - ResCell  
  - ResTable

## :movie_camera: Screencast/Demo  
https://drive.google.com/file/d/1s1lk4SeDdnpYjqxQkr8Tvv3aajP0pHT_/view?usp=sharing

## :bulb: Additional context you want to provide?  
- Users who don't have any active bookings on the selected day can click on the white/free cells to trigger the reservation composer modal.  
- The modal has validation functionality; if users try to make a reservation that conflicts with the existing bookings, the modal will show error texts to guide users to select different timing or stalls.  
- If the user has a booking on the day, clicking on the white/free cells won't trigger the reservation composer modal.  
- One booking is range from 1 hour to 3 hours.  
- QA notes: 1. `git fetch`; 2. git checkout f27 branch; 3. `git pull origin web-f27-reservation-v2`; 4. `npm i`; 5. `npm start` to test it.  