### PR TITLE
Web f33 forgot pass ui

### DIFF
--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -6,6 +6,7 @@ import Toolbar from '@material-ui/core/Toolbar'
 import NavContent from './NavContent'
 import NavHome from './NavHome'
 import LoginForm from '../userAuth/LoginForm'
+import ForgotPass from '../userAuth/ForgotPass'
 import SignupForm from '../userAuth/SignupForm'
 import Spinner from '../util/Spinner'
 import firebaseApp from '../../firebase'
@@ -54,6 +55,7 @@ export default class Navbar extends Component {
           </AppBar>
           <Route exact path='/' render={() => <NavHome login={login} />} />
           <Route path='/login' render={() => <LoginForm login={login} />} />
+          <Route path='/forgot-password' render={() => <ForgotPass />} />
           <Route path='/signup' render={() => <SignupForm login={login} />} />
         </Fragment>
       </BrowserRouter>

--- a/src/components/userAuth/ForgotPass.js
+++ b/src/components/userAuth/ForgotPass.js
@@ -1,0 +1,80 @@
+import React, { Component, Fragment } from 'react'
+import styled from 'styled-components'
+import { Button, Form, Input, Title } from './LoginForm'
+import firebaseApp from '../../firebase'
+
+
+const AlignWrapper = styled.div`
+  display: inline-block;
+  text-align: left;
+`
+
+const Text = styled.span`
+  color: white;
+  padding: 25px;
+`
+
+const ErrMsg = styled.span`
+  color: orangered;
+  padding: 10px;
+  margin: 10px;
+`
+
+const rgEmail = /\S+@\S+\.\S+/
+const auth = firebaseApp.auth()
+
+export default class ForgotPass extends Component {
+  state = {
+    email: '',
+    error: false
+  }
+
+  componentDidMount() {
+    this.setState({ error: false })
+  }
+
+  handleChange = e => {
+    this.setState({ [e.target.name]: e.target.value })
+  }
+
+  handleSubmit = e => {
+    e.preventDefault()
+    const { email } = this.state
+    if (rgEmail.test(email)) {
+      auth.sendPasswordResetEmail(email)
+        .then(() => {
+          console.log('reset request sent')
+          this.setState({ error: false })
+        })
+        .catch(err => console.log(err))
+    }
+    else {
+      this.setState({ error: true })
+    }
+  }
+
+  render() {
+    const { error } = this.state
+    return (
+      <Form onSubmit={this.handleSubmit}>
+        <AlignWrapper>
+          <Title>Forgot Password?</Title>
+          <br />
+          <Text>To reset password, type the full email address</Text>
+          <br />
+          <Input name='email' placeholder='email' onChange={this.handleChange} error={error} style={{margin: '10px 20px'}} />
+          <br />
+          <br />
+          <Button style={{margin: '0 20px 10px 20px'}} type='submit'>submit</Button>
+          {error && (
+            <Fragment>
+              <br />
+              <ErrMsg>Email format is incorrect. Please enter again</ErrMsg>
+            </Fragment>
+          )}
+        </AlignWrapper>
+
+      </Form>
+    )
+  }
+}

--- a/src/components/userAuth/ForgotPass.js
+++ b/src/components/userAuth/ForgotPass.js
@@ -65,7 +65,6 @@ export default class ForgotPass extends Component {
     if (rgEmail.test(email)) {
       auth.sendPasswordResetEmail(email)
         .then(() => {
-          console.log('reset request sent')
           this.setState({
             email: '',
             error: false,

--- a/src/components/userAuth/ForgotPass.js
+++ b/src/components/userAuth/ForgotPass.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { Button, Form, Input, Title } from './LoginForm'
 import firebaseApp from '../../firebase'
@@ -14,10 +15,27 @@ const Text = styled.span`
   padding: 25px;
 `
 
-const ErrMsg = styled.span`
+const ErrMsg = styled.div`
   color: orangered;
-  padding: 10px;
-  margin: 10px;
+  padding: 0 10px;
+  margin: 0 10px;
+`
+
+const LinkStyle = {
+  fontFamily: 'Gill Sans, sans-serif',
+  color: 'lawngreen',
+  textDecoration: 'underline'
+}
+
+const InputStyle = {
+  margin: '10px 20px',
+  width: '300px'
+}
+
+const SuccessMsg = styled.div`
+  color: lawngreen;
+  padding: 0 10px;
+  margin: 0 10px;
 `
 
 const rgEmail = /\S+@\S+\.\S+/
@@ -26,14 +44,18 @@ const auth = firebaseApp.auth()
 export default class ForgotPass extends Component {
   state = {
     email: '',
-    error: false
+    error: false,
+    success: false,
   }
 
   componentDidMount() {
-    this.setState({ error: false })
+    this.setState({ error: false, success: false })
   }
 
   handleChange = e => {
+    if (this.state.email === '') {
+      this.setState({ error: false, success: false })
+    }
     this.setState({ [e.target.name]: e.target.value })
   }
 
@@ -44,9 +66,19 @@ export default class ForgotPass extends Component {
       auth.sendPasswordResetEmail(email)
         .then(() => {
           console.log('reset request sent')
-          this.setState({ error: false })
+          this.setState({
+            email: '',
+            error: false,
+            success: true
+          })
         })
-        .catch(err => console.log(err))
+        .catch(() => {
+          this.setState({
+            email: '',
+            error: false,
+            success: true
+          })
+        })
     }
     else {
       this.setState({ error: true })
@@ -54,7 +86,7 @@ export default class ForgotPass extends Component {
   }
 
   render() {
-    const { error } = this.state
+    const { error, success, email } = this.state
     return (
       <Form onSubmit={this.handleSubmit}>
         <AlignWrapper>
@@ -62,18 +94,27 @@ export default class ForgotPass extends Component {
           <br />
           <Text>To reset password, type the full email address</Text>
           <br />
-          <Input name='email' placeholder='email' onChange={this.handleChange} error={error} style={{margin: '10px 20px'}} />
+          <Input value={email} name='email' placeholder='email' onChange={this.handleChange} error={error} style={InputStyle} />
           <br />
           <br />
-          <Button style={{margin: '0 20px 10px 20px'}} type='submit'>submit</Button>
+          <Button style={{margin: '0 5px 10px 20px'}} type='submit'>submit</Button>
           {error && (
             <Fragment>
               <br />
               <ErrMsg>Email format is incorrect. Please enter again</ErrMsg>
             </Fragment>
           )}
+          {success && (
+            <Fragment>
+              <br />
+              <SuccessMsg>
+                We have emailed you password reset link!
+                <br />
+                <Link to='/login' style={LinkStyle}>Click here to go back to login</Link>
+              </SuccessMsg>
+            </Fragment>
+          )}
         </AlignWrapper>
-
       </Form>
     )
   }

--- a/src/components/userAuth/LoginForm.js
+++ b/src/components/userAuth/LoginForm.js
@@ -138,7 +138,7 @@ class LoginForm extends Component {
             <br/>
             <Button type='submit'>LOGIN</Button>
             <br/>
-            <LabelSmall><Link to='/forgot-password' style={LinkStyle}>Forgot Password?</Link></LabelSmall> {/* TODO: create reset-pass component */}
+            <LabelSmall><Link to='/forgot-password' style={LinkStyle}>Forgot Password?</Link></LabelSmall>
             <br/>
           </Form>
         </div>

--- a/src/components/userAuth/LoginForm.js
+++ b/src/components/userAuth/LoginForm.js
@@ -138,7 +138,7 @@ class LoginForm extends Component {
             <br/>
             <Button type='submit'>LOGIN</Button>
             <br/>
-            <LabelSmall><Link to='/signup' style={LinkStyle}>Forget Password</Link></LabelSmall> {/* TODO: create reset-pass component */}
+            <LabelSmall><Link to='/forgot-password' style={LinkStyle}>Forgot Password?</Link></LabelSmall> {/* TODO: create reset-pass component */}
             <br/>
           </Form>
         </div>

--- a/stories/index.js
+++ b/stories/index.js
@@ -7,6 +7,7 @@ import BackupIcon from '@material-ui/icons/Backup'
 
 import LoginForm from '../src/components/userAuth/LoginForm'
 import SignupForm from '../src/components/userAuth/SignupForm'
+import ForgotPass from '../src/components/userAuth/ForgotPass'
 import Navbar from '../src/components/navigation/Navbar'
 import NavItem from '../src/components/navigation/NavItem'
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
@@ -52,6 +53,9 @@ storiesOf('React Component', module)
   ))
   .add('Signup form V1', () => (
     <SignupForm />
+  ))
+  .add('Forgot Password V1', () => (
+    <ForgotPass />
   ))
   .add('Parking Status Table', () => (
     <ParkingStatus />

--- a/stories/index.js
+++ b/stories/index.js
@@ -7,7 +7,6 @@ import BackupIcon from '@material-ui/icons/Backup'
 
 import LoginForm from '../src/components/userAuth/LoginForm'
 import SignupForm from '../src/components/userAuth/SignupForm'
-import ForgotPass from '../src/components/userAuth/ForgotPass'
 import Navbar from '../src/components/navigation/Navbar'
 import NavItem from '../src/components/navigation/NavItem'
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
@@ -53,9 +52,6 @@ storiesOf('React Component', module)
   ))
   .add('Signup form V1', () => (
     <SignupForm />
-  ))
-  .add('Forgot Password V1', () => (
-    <ForgotPass />
   ))
   .add('Parking Status Table', () => (
     <ParkingStatus />


### PR DESCRIPTION
## :rocket: What does this PR implement/fix?  
- Create a page to reset password in case users forgot their password.  

## :book: Where should the reviewers start?  
- Take a take at /userAuth/ForgotPass.js

## :movie_camera: Screencast/Demo  
n/a  

## :bulb: Additional context you want to provide?  
- Users only receive the reset-password email if the email has been used to register the account in iPark.  
- QA notes: 1. `git fetch`; 2. git checkout branch f33; 3. `npm start` to test. You can access the forgot password page through clicking on the forgot password text on the login form.  