### PR TITLE
Web f30 booking ref v1

### DIFF
--- a/src/components/reservation/ResRef.js
+++ b/src/components/reservation/ResRef.js
@@ -1,33 +1,111 @@
-import React from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import Typography from '@material-ui/core/Typography';
-import TextField from '@material-ui/core/TextField';
-import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography'
+import TextField from '@material-ui/core/TextField'
+import Button from '@material-ui/core/Button'
+import Modal from '@material-ui/core/Modal'
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 
-const WrapperTextField = styled.div`
-  
-`
+const modalStyle = {
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '400px',
+  maxWidth: '100%',
+  backgroundColor: 'white',
+  padding: '32px',
+  borderRadius: '10px',
+  boxShadow: '0 3px 7px rgba(0, 0, 0, 0.3)',
+  border: '1px solid rgba(0, 0, 0, 0.3)',
+  textAlign: 'center'
+}
 
-const ResRef = () => {
-  return(
-    <WrapperTextField>
-      <Typography variant='h6' gutterBottom>Reservation Successful</Typography>
-      <TextField
-        label="Booking Reference"
-        defaultValue='Reference Num'
-        InputProps={{
-          readOnly: true,
-        }}
-        inputProps={{
-          style: { textAlign: 'center'}
-        }}
-        variant='outlined'
-      />
-      <br/>
-      <Button>CLOSE</Button>
-    </WrapperTextField>
-  )
+const headerStyle = {
+  margin: '0px 0px 20px 0px',
+  color: 'Green',
+}
+
+const bottonStyle = {
+  margin: '20px 0px 0px 0px',
+  color: 'Green'
+}
+
+const bodyStyle = {
+  margin: '10px 0px 0px 0px',
+  color: 'DarkSlateGray'
+}
+
+const bookRefStyle = {
+  letterSpacing: '10px'
+}
+
+const theme = createMuiTheme({
+  palette: {
+    primary: { main: '#32CD32'}
+  },
+  typography: {
+    useNextVariants: true,
+  }
+})
+
+class ResRef extends Component {
+  state = {
+    open: false
+  }
+
+  handleOpen = () => {
+    this.setState({open: true})
+  }
+  handleClose = () => {
+    this.setState({open: false})
+  }
+
+  render(){
+    let RefNum = '0930'
+    return(
+      //<MuiThemeProvider theme={theme}> </MuiThemeProvider>
+      <MuiThemeProvider theme={theme}>
+        <Typography gutterBottom>Placeholder for reserve button</Typography>
+        <Button onClick={this.handleOpen}>Reserve</Button>
+        <Modal
+          aria-labelledby="simple-modal-title"
+          aria-describedby="simple-modal-description"
+          open={this.state.open}
+          onClose={this.handleClose}
+        >
+          <div style={modalStyle}>
+            <Typography variant="h6" id="modal-title" style = {headerStyle}>
+              SUCCESS!
+            </Typography>
+            <TextField
+              label = 'Booking Reference'
+              defaultValue = {RefNum}
+              autoFocus
+              InputProps = {{
+                readOnly: true,
+              }}
+              inputProps = {{
+                style: { textAlign: 'center', letterSpacing: '10px', width: '200px', fontSize: '30px', color: 'DarkSlateGray'}
+              }}
+              InputLabelProps = {{
+                style: { color: 'LimeGreen'}
+              }}
+              variant='outlined'
+            />
+            <Typography variant="body2" id="modal-title" style = {bodyStyle}>
+              Please keep this reference number for booking validation
+            </Typography>
+            <br/>
+            <Button style = {bottonStyle} onClick={this.handleClose}>
+              OK
+            </Button>
+          </div>
+        </Modal>
+      </MuiThemeProvider>
+    )
+  }
 }
 
 export default ResRef

--- a/src/components/reservation/ResRef.js
+++ b/src/components/reservation/ResRef.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+
+const WrapperTextField = styled.div`
+  
+`
+
+const ResRef = () => {
+  return(
+    <WrapperTextField>
+      <Typography variant='h6' gutterBottom>Reservation Successful</Typography>
+      <TextField
+        label="Booking Reference"
+        defaultValue='Reference Num'
+        InputProps={{
+          readOnly: true,
+        }}
+        inputProps={{
+          style: { textAlign: 'center'}
+        }}
+        variant='outlined'
+      />
+      <br/>
+      <Button>CLOSE</Button>
+    </WrapperTextField>
+  )
+}
+
+export default ResRef

--- a/src/components/reservation/ResRef.js
+++ b/src/components/reservation/ResRef.js
@@ -1,6 +1,4 @@
 import React, {Component} from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import Typography from '@material-ui/core/Typography'
 import TextField from '@material-ui/core/TextField'
 import Button from '@material-ui/core/Button'
@@ -29,16 +27,13 @@ const headerStyle = {
 
 const bottonStyle = {
   margin: '20px 0px 0px 0px',
-  color: 'Green'
+  color: 'Green',
+  fontSize: '18px'
 }
 
 const bodyStyle = {
   margin: '10px 0px 0px 0px',
   color: 'DarkSlateGray'
-}
-
-const bookRefStyle = {
-  letterSpacing: '10px'
 }
 
 const theme = createMuiTheme({

--- a/src/components/reservation/ResRef.js
+++ b/src/components/reservation/ResRef.js
@@ -23,12 +23,15 @@ const modalStyle = {
 const headerStyle = {
   margin: '0px 0px 20px 0px',
   color: 'Green',
+  fontWeight: 'bold',
+  fontSize: '25px'
 }
 
 const bottonStyle = {
   margin: '20px 0px 0px 0px',
   color: 'Green',
-  fontSize: '18px'
+  fontSize: '18px',
+  fontWeight: 'bold'
 }
 
 const bodyStyle = {
@@ -82,7 +85,7 @@ class ResRef extends Component {
                 readOnly: true,
               }}
               inputProps = {{
-                style: { textAlign: 'center', letterSpacing: '10px', width: '200px', fontSize: '30px', color: 'DarkSlateGray'}
+                style: { textAlign: 'center', letterSpacing: '10px', width: '200px', fontSize: '30px', color: 'DarkSlateGray', fontWeight: 'bold'}
               }}
               InputLabelProps = {{
                 style: { color: 'LimeGreen'}

--- a/src/components/reservation/ResRef.js
+++ b/src/components/reservation/ResRef.js
@@ -41,7 +41,7 @@ const bodyStyle = {
 
 const theme = createMuiTheme({
   palette: {
-    primary: { main: '#32CD32'}
+    primary: { main: '#32CD32' }
   },
   typography: {
     useNextVariants: true,
@@ -54,16 +54,15 @@ class ResRef extends Component {
   }
 
   handleOpen = () => {
-    this.setState({open: true})
+    this.setState({ open: true })
   }
   handleClose = () => {
-    this.setState({open: false})
+    this.setState({ open: false })
   }
 
   render(){
     let RefNum = '0930'
     return(
-      //<MuiThemeProvider theme={theme}> </MuiThemeProvider>
       <MuiThemeProvider theme={theme}>
         <Typography gutterBottom>Placeholder for reserve button</Typography>
         <Button onClick={this.handleOpen}>Reserve</Button>
@@ -74,29 +73,30 @@ class ResRef extends Component {
           onClose={this.handleClose}
         >
           <div style={modalStyle}>
-            <Typography variant="h6" id="modal-title" style = {headerStyle}>
+            <Typography variant="h6" id="modal-title" style={headerStyle}>
               SUCCESS!
             </Typography>
             <TextField
-              label = 'Booking Reference'
-              defaultValue = {RefNum}
+              label='Booking Reference'
+              defaultValue={RefNum}
               autoFocus
-              InputProps = {{
+              InputProps={{
                 readOnly: true,
               }}
-              inputProps = {{
-                style: { textAlign: 'center', letterSpacing: '10px', width: '200px', fontSize: '30px', color: 'DarkSlateGray', fontWeight: 'bold'}
+              inputProps={{
+                style: { textAlign: 'center', letterSpacing: '10px', width: '200px',
+                  fontSize: '30px', color: 'DarkSlateGray', fontWeight: 'bold' }
               }}
-              InputLabelProps = {{
-                style: { color: 'LimeGreen'}
+              InputLabelProps={{
+                style: { color: 'LimeGreen' }
               }}
               variant='outlined'
             />
-            <Typography variant="body2" id="modal-title" style = {bodyStyle}>
+            <Typography variant="body2" id="modal-title" style={bodyStyle}>
               Please keep this reference number for booking validation
             </Typography>
             <br/>
-            <Button style = {bottonStyle} onClick={this.handleClose}>
+            <Button style={bottonStyle} onClick={this.handleClose}>
               OK
             </Button>
           </div>

--- a/stories/index.js
+++ b/stories/index.js
@@ -12,6 +12,7 @@ import NavItem from '../src/components/navigation/NavItem'
 import ParkingStatus from '../src/components/parkingInfo/ParkingStatus'
 import ResCalendar from '../src/components/reservation/ResCalendar'
 import ResMain from '../src/components/reservation/ResMain'
+import ResRef from '../src/components/reservation/ResRef'
 
 
 let buttonStyle = {
@@ -67,4 +68,7 @@ storiesOf('React Component', module)
   ))
   .add('Reservation main page', () => (
     <ResMain />
+  ))
+  .add('Reservation reference page', () => (
+    <ResRef />
   ))


### PR DESCRIPTION
## :rocket: What does this PR implement/fix?  
- Create a booking reference page that will be further integrated with reservation feature  

## :book: Where should the reviewers start?  
- Check ResRef.js  
- After clicking the "RESERVE" button, the reference page should prompt up  
- The reference page should automatically close after clicking the "OK" button  

## :movie_camera: Screencast/Demo  
![image](https://user-images.githubusercontent.com/32072985/60367545-4b169180-99a3-11e9-92e6-f307ba5fd98d.png)

## :bulb: Additional context you want to provide?  
- The "RESERVE" button just a placeholder  
- The modal will be directed from the reservation page  
- No QA needed for this pull request  